### PR TITLE
Feature/implementation event store methods

### DIFF
--- a/src/main/java/net/intelie/challenges/impl/EventIteratorImpl.java
+++ b/src/main/java/net/intelie/challenges/impl/EventIteratorImpl.java
@@ -18,6 +18,10 @@ public class EventIteratorImpl implements EventIterator {
     private Iterator<Event> iterator;
     private Event event;
 
+    public EventIteratorImpl(Iterator<Event> iterator) {
+        this.iterator = iterator;
+    }
+
     @Override
     public boolean moveNext() {
         if (this.iterator.hasNext()) {

--- a/src/main/java/net/intelie/challenges/impl/EventStoreImpl.java
+++ b/src/main/java/net/intelie/challenges/impl/EventStoreImpl.java
@@ -5,6 +5,8 @@
  */
 package net.intelie.challenges.impl;
 
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentSkipListMap;
 import net.intelie.challenges.Event;
 import net.intelie.challenges.EventIterator;
 import net.intelie.challenges.EventStore;
@@ -15,24 +17,28 @@ import net.intelie.challenges.EventStore;
  */
 public class EventStoreImpl implements EventStore {
 
+    private final ConcurrentSkipListMap<String, Event> eventStore = new ConcurrentSkipListMap<>();
+
     @Override
     public void insert(Event event) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        this.eventStore.putIfAbsent(event.getId(), event);
     }
 
     @Override
     public void removeAll(String type) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        this.eventStore.values().stream().filter((event) -> (event.getType().equals(type))).forEachOrdered((event) -> {
+            this.eventStore.remove(event.getId());
+        });
     }
 
     @Override
     public EventIterator query(String type, long startTime, long endTime) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        Iterator<Event> iterator = eventStore.values().stream().filter(event -> type.equals(event.getType()) && startTime <= event.getTimestamp() && endTime > event.getTimestamp()).iterator();
+        return new EventIteratorImpl(iterator);
     }
 
     @Override
     public int size() {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        return this.eventStore.size();
     }
-    
 }


### PR DESCRIPTION
* Implementation of EventStore methods.
  * **insert** -> Insert an event in the structure.
  * **removeAll** -> Removes of all events of a specific type from the structure.
  * **size** -> Return the event store structure size.
  * **query** -> Returns an iterator of the structure from the filter used. The filter is determined by the type, start time, and end time of the event. 

* Structure chosen.
**ConcurrentSkipListMap** -> This class implements a concurrent variant of SkipLists providing expected average log(n) time cost for the containsKey, get, put and remove operations and their variants. Insertion, removal, update, and access operations safely execute concurrently by multiple threads.

For more informations see: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentSkipListMap.html

Initially I considered using the **ConcurrentHashMap** structure, as well as being a thread-safe structure has the order to put and get multithreaded in **O (1)**. But I chose b, which has the order of **O (log n)** (which is not much of a difference), because it offers a more efficient ordered search, and in an evolution to priority-ordered events, this functionality becomes more appropriate.